### PR TITLE
Chad/#34 event filter screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react": "16.0.0-alpha.12",
     "react-native": "^0.48.4",
     "react-native-maps": "^0.17.1",
+    "react-native-modal-datetime-picker": "^4.13.0",
     "react-navigation": "^1.0.0-beta.13",
     "react-redux": "^5.0.6",
     "redux": "^3.7.2"

--- a/src/views/EventFilter.js
+++ b/src/views/EventFilter.js
@@ -1,23 +1,80 @@
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
     StyleSheet,
+    TouchableOpacity,
     Text,
     View
 } from 'react-native';
+import { connect } from 'react-redux';
+import { addEvents, clearEvents } from './../actions/events';
+import { getEvents } from './../api';
+import DateTimePicker from 'react-native-modal-datetime-picker';
+import Moment from 'moment';
 
-export default class EventFilter extends Component {
-    render () {
+
+class EventFilter extends Component {
+    state = {
+        isDateTimePickerVisible: false,
+    };
+
+    _showDateTimePicker = () => this.setState({ isDateTimePickerVisible: true });
+
+    _hideDateTimePicker = () => this.setState({ isDateTimePickerVisible: false });
+
+    _handleDatePicked = (date) => {
+        getEvents(
+            // Set start/end window because backend requires both.
+            { ...this.props.location,
+                start_time: Moment(date).format('YYYY-MM-DD'),
+                end_time: Moment(date).add(1, 'days').format('YYYY-MM-DD') }
+            ).then(
+                res => this.props.addEvents(res),
+                err => console.log(err) || props.addEvents([mockEvent])
+        );
+        console.log('A date has been picked: ', Moment(date));
+        this._hideDateTimePicker();
+    };
+
+    render() {
         return (
-            <View style={styles.container}>
-                <Text>Filter events by location, price, etc.</Text>
+            <View style={{ flex: 1 }}>
+                <TouchableOpacity onPress={this._showDateTimePicker}>
+                    <Text>Set Date</Text>
+                </TouchableOpacity>
+                <DateTimePicker
+                    isVisible={this.state.isDateTimePickerVisible}
+                    onConfirm={this._handleDatePicked}
+                    onCancel={this._hideDateTimePicker}
+                />
             </View>
         );
     }
+
 }
 
 EventFilter.navigationOptions = {
     title: 'Filter'
 };
+
+
+const mapDispatchToProps = dispatch => ({
+    addEvents: events => dispatch(addEvents(events)),
+    clearEvents: () => dispatch(clearEvents())
+});
+
+
+// Pull new events from redux into props.
+const mapStateToProps = state => ({
+    events: state.events.events
+});
+
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(EventFilter);
+
 
 const styles = StyleSheet.create({
     container: {

--- a/src/views/EventFilter.js
+++ b/src/views/EventFilter.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
+    Button,
     StyleSheet,
     TouchableOpacity,
     Text,
@@ -30,7 +31,7 @@ class EventFilter extends Component {
                 end_time: Moment(date).add(1, 'days').format('YYYY-MM-DD') }
             ).then(
                 res => this.props.addEvents(res),
-                err => console.log(err) || props.addEvents([mockEvent])
+                err => console.log(err) || this.props.addEvents([mockEvent])
         );
         console.log('A date has been picked: ', Moment(date));
         this._hideDateTimePicker();
@@ -38,10 +39,8 @@ class EventFilter extends Component {
 
     render() {
         return (
-            <View style={{ flex: 1 }}>
-                <TouchableOpacity onPress={this._showDateTimePicker}>
-                    <Text>Set Date</Text>
-                </TouchableOpacity>
+            <View style={styles.container}>
+                <Button onPress={this._showDateTimePicker} title="Set date" />
                 <DateTimePicker
                     isVisible={this.state.isDateTimePickerVisible}
                     onConfirm={this._handleDatePicked}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4099,7 +4099,7 @@ moment@2.x.x, moment@^2.10.6:
   version "2.18.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.18.1.tgz#c36193dd3ce1c2eed2adb7c802dbbc77a81b1c0f"
 
-moment@^2.19.1:
+moment@^2.19.0, moment@^2.19.1:
   version "2.19.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.19.1.tgz#56da1a2d1cbf01d38b7e1afc31c10bcfa1929167"
 
@@ -4656,6 +4656,13 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@15.5.10:
+  version "15.5.10"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
+  dependencies:
+    fbjs "^0.8.9"
+    loose-envify "^1.3.1"
+
 prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.5.8:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
@@ -4794,6 +4801,12 @@ react-devtools-core@^2.5.0:
     shell-quote "^1.6.1"
     ws "^2.0.3"
 
+react-native-animatable@^1.2.3:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/react-native-animatable/-/react-native-animatable-1.2.4.tgz#b5fb7657e8f6edadbc26697057a327fb920b3039"
+  dependencies:
+    prop-types "^15.5.10"
+
 react-native-branch@2.0.0-beta.3:
   version "2.0.0-beta.3"
   resolved "https://registry.yarnpkg.com/react-native-branch/-/react-native-branch-2.0.0-beta.3.tgz#2167af86bbc9f964bd45bd5f37684e5b54965e32"
@@ -4827,6 +4840,21 @@ react-native-maps@0.15.3:
 react-native-maps@^0.17.1:
   version "0.17.1"
   resolved "https://registry.yarnpkg.com/react-native-maps/-/react-native-maps-0.17.1.tgz#ab2236341fd984dac8864202ae55331bc262f60c"
+
+react-native-modal-datetime-picker@^4.13.0:
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/react-native-modal-datetime-picker/-/react-native-modal-datetime-picker-4.13.0.tgz#bcf9f62c691befb133bf6fd6e5d6189d397608ef"
+  dependencies:
+    moment "^2.19.0"
+    prop-types "15.5.10"
+    react-native-modal "3.1.0"
+
+react-native-modal@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-modal/-/react-native-modal-3.1.0.tgz#3e6911152e9dcd6e15457cf0c24d7fd833c4a57a"
+  dependencies:
+    prop-types "15.5.10"
+    react-native-animatable "^1.2.3"
 
 react-native-safe-module@^1.1.0:
   version "1.2.0"


### PR DESCRIPTION
⏳ Status: _Open for visibility_

# 👷 Changes

+ Added a date filter.
+ Added a datetime picker.
+ Updated event redux store on date pick.

# 🏁 Testing Instructions

+ Go to event filter page, click Set Date. Ensure the events in the lister update to your spec.

# ☑️ TODO

- [x] ~Add location filter (the other filtration the backend can handle right now).~

What other filtration do we want? We're only collecting Vancouver on BE right now, we can open that up to BC-wide pretty easily I suppose 🤔. Location isn't very exciting because we're using location services anyways.